### PR TITLE
「Deploy to Heroku」利用時に検索でエラーとなるため手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Using Heroku
 
 1. go to https://heroku.com/deploy
 1. input INSTALL_PLUGINS to install plugins
+1. Upgrade Bonsai ( -> 5.x.x )
 
 Using docker-compose
 ---------------------


### PR DESCRIPTION
「Deploy to Heroku」利用時に検索でエラーとなるため、手順の追加
Bonsaiのバージョンが初期設定では古い為、管理画面からアップグレードが必要