### PR TITLE
fix #155: Bug: Recursively option processes also unexpedted pages

### DIFF
--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -610,11 +610,22 @@ module.exports = function(crowi) {
   };
 
   /**
-   * findListByStartWith
+   * find the page that is match with `path` and its descendants
+   */
+  pageSchema.statics.findListWithDescendants = function(path, userData, option) {
+    var Page = this;
+
+    // add slash to the last
+    path = path + (path == '/' ? '' : '/');
+
+    return Page.findListByStartWith(path, userData, option);
+  };
+
+  /**
+   * find pages that start with `path`
    *
    * If `path` has `/` at the end, returns '{path}/*' and '{path}' self.
    * If `path` doesn't have `/` at the end, returns '{path}*'
-   * e.g.
    */
   pageSchema.statics.findListByStartWith = function(path, userData, option) {
     var Page = this;
@@ -657,6 +668,24 @@ module.exports = function(crowi) {
     });
   };
 
+  /**
+   * generate the query to find the page that is match with `path` and its descendants
+   */
+  pageSchema.statics.generateQueryToListWithDescendants = function(path, userData, option) {
+    var Page = this;
+
+    // add slash to the last
+    path = path + (path == '/' ? '' : '/');
+
+    return Page.generateQueryToListByStartWith(path, userData, option);
+  };
+
+  /**
+   * generate the query to find pages that start with `path`
+   *
+   * If `path` has `/` at the end, returns '{path}/*' and '{path}' self.
+   * If `path` doesn't have `/` at the end, returns '{path}*'
+   */
   pageSchema.statics.generateQueryToListByStartWith = function(path, userData, option) {
     var Page = this;
     var pathCondition = [];
@@ -890,7 +919,7 @@ module.exports = function(crowi) {
 
     return new Promise(function (resolve, reject) {
       Page
-      .generateQueryToListByStartWith(path, user, options)
+      .generateQueryToListWithDescendants(path, user, options)
       .then(function (pages) {
         Promise.all(pages.map(function (page) {
           return Page.deletePage(page, user, options);
@@ -941,7 +970,7 @@ module.exports = function(crowi) {
 
       return new Promise(function (resolve, reject) {
         Page
-        .generateQueryToListByStartWith(path, user, options)
+        .generateQueryToListWithDescendants(path, user, options)
         .then(function (pages) {
           Promise.all(pages.map(function (page) {
             return Page.revertDeletedPage(page, user, options);
@@ -997,7 +1026,7 @@ module.exports = function(crowi) {
 
     return new Promise(function (resolve, reject) {
       Page
-      .generateQueryToListByStartWith(path, user, options)
+      .generateQueryToListWithDescendants(path, user, options)
       .then(function (pages) {
         Promise.all(pages.map(function (page) {
           return Page.completelyDeletePage(page, user, options);
@@ -1095,7 +1124,7 @@ module.exports = function(crowi) {
 
     return new Promise(function(resolve, reject) {
       Page
-      .generateQueryToListByStartWith(path, user, options)
+      .generateQueryToListWithDescendants(path, user, options)
       .then(function(pages) {
         Promise.all(pages.map(function(page) {
           newPagePath = page.path.replace(pathRegExp, newPagePathPrefix);

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -616,7 +616,7 @@ module.exports = function(crowi) {
     var Page = this;
 
     // add slash to the last
-    path = path + (path == '/' ? '' : '/');
+    path = Page.addSlashOfEnd(path);
 
     return Page.findListByStartWith(path, userData, option);
   };
@@ -675,7 +675,7 @@ module.exports = function(crowi) {
     var Page = this;
 
     // add slash to the last
-    path = path + (path == '/' ? '' : '/');
+    path = Page.addSlashOfEnd(path);
 
     return Page.generateQueryToListByStartWith(path, userData, option);
   };
@@ -1142,6 +1142,17 @@ module.exports = function(crowi) {
     // TODO
     return;
   };
+
+  /**
+   * return path that added slash to the end for specified path
+   */
+  pageSchema.statics.addSlashOfEnd = function(path) {
+    let returnPath = path;
+    if (!path.match(/\/$/)) {
+      returnPath += '/';
+    }
+    return returnPath;
+  }
 
   pageSchema.statics.GRANT_PUBLIC = GRANT_PUBLIC;
   pageSchema.statics.GRANT_RESTRICTED = GRANT_RESTRICTED;

--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -176,7 +176,7 @@ module.exports = function(crowi, app) {
     }).then(function(tree) {
       renderVars.tree = tree;
 
-      return Page.findListByStartWith(path, req.user, queryOptions);
+      return Page.findListWithDescendants(path, req.user, queryOptions);
     }).then(function(pageList) {
 
       if (pageList.length > limit) {
@@ -303,7 +303,7 @@ module.exports = function(crowi, app) {
     // get list pages
     .then(function() {
       if (!isRedirect) {
-        Page.findListByStartWith(path, req.user, queryOptions)
+        Page.findListWithDescendants(path, req.user, queryOptions)
         .then(function(pageList) {
           if (pageList.length > limit) {
             pageList.pop();
@@ -355,7 +355,7 @@ module.exports = function(crowi, app) {
       pages: [],
     };
 
-    Page.findListByStartWith(path, req.user, queryOptions)
+    Page.findListWithDescendants(path, req.user, queryOptions)
     .then(function(pageList) {
 
       if (pageList.length > limit) {

--- a/lib/routes/page.js
+++ b/lib/routes/page.js
@@ -142,7 +142,7 @@ module.exports = function(crowi, app) {
     var limit = 50;
     var offset = parseInt(req.query.offset)  || 0;
     var SEENER_THRESHOLD = 10;
-    // add slash to the last
+    // add slash if root
     path = path + (path == '/' ? '' : '/');
 
     debug('Page list show', path);


### PR DESCRIPTION
use properly `findListByStartWith` and `findListWithDescendants`