### PR TITLE
Change emojify.js to emojione

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "diff": "^3.3.0",
     "diff2html": "^2.3.0",
     "elasticsearch": "^14.0.0",
-    "emojify.js": "^1.1.0",
+    "emojione": "^3.1.2",
     "env-cmd": "^7.0.0",
     "escape-string-regexp": "^1.0.5",
     "express": "^4.16.1",

--- a/resource/css/_wiki.scss
+++ b/resource/css/_wiki.scss
@@ -144,7 +144,7 @@ div.body {
     border: none;
   }
 
-  img.emoji {
+  img.emojione {
     width: 1.1em;
     margin: 1px;
     border: none;

--- a/resource/js/util/PostProcessor/Emoji.js
+++ b/resource/js/util/PostProcessor/Emoji.js
@@ -1,15 +1,8 @@
-import emojify from 'emojify.js';
+import emojione from 'emojione';
 
 export default class Emoji {
 
-  constructor() {
-    // see https://github.com/Ranks/emojify.js/issues/123
-    emojify.setConfig({
-      img_dir: 'https://github.global.ssl.fastly.net/images/icons/emoji/',
-    });
-  }
-
   process(markdown) {
-    return emojify.replace(markdown);
+    return emojione.shortnameToImage(markdown);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,9 +1899,9 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-emojify.js@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/emojify.js/-/emojify.js-1.1.0.tgz#079fff223307c9007f570785e8e4935d5c398beb"
+emojione@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/emojione/-/emojione-3.1.2.tgz#991e30c80db4b1cf15eacb257620a7edce9c6ef4"
 
 emojis-list@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Because,

-   emojify.js is already unmaintained.

-   `emojify.replace()` can't detect emojiname at the beginning of a line.

    e.g.

    ```markdown
    :hatched_chick: piyopiyo
    ```

    ```markdown
    ## :hatched_chick: piyopiyo
    ```