### PR TITLE
fixed #239: "Comments for Newer Revision" to be opened with default

### DIFF
--- a/resource/js/components/PageComments.js
+++ b/resource/js/components/PageComments.js
@@ -165,7 +165,7 @@ export default class PageComments extends React.Component {
       </div>
     );
     const newerBlock = (
-      <div className="page-comments-list-newer collapse" id="page-comments-list-newer">
+      <div className="page-comments-list-newer collapse in" id="page-comments-list-newer">
         {newerElements}
       </div>
     );


### PR DESCRIPTION
* add "in" class for "Comments for Newer Revision"