### PR TITLE
fix/250-enter-key-doesnot-work-on-create_page_under

### DIFF
--- a/resource/js/components/NewPageNameInputter.js
+++ b/resource/js/components/NewPageNameInputter.js
@@ -52,18 +52,13 @@ export default class NewPageNameInputter extends React.Component {
       : 'No matches found on title...';
 
     return (
-      <form
-        action="/_search"
-        className=""
-      >
-        <SearchTypeahead
-          crowi={this.crowi}
-          onSearchError={this.onSearchError}
-          emptyLabel={emptyLabel}
-          placeholder="Input page name"
-          keywordOnInit={this.getParentPageName(this.props.parentPageName)}
-        />
-      </form>
+      <SearchTypeahead
+        crowi={this.crowi}
+        onSearchError={this.onSearchError}
+        emptyLabel={emptyLabel}
+        placeholder="Input page name"
+        keywordOnInit={this.getParentPageName(this.props.parentPageName)}
+      />
     );
   }
 }


### PR DESCRIPTION
refs issue#250
- Removed form tag which is parent of SearchTypeahead in order to catch entering action of return key.