### PR TITLE
fix: Update comment count of a page on comment deletion

### DIFF
--- a/lib/models/comment.js
+++ b/lib/models/comment.js
@@ -122,10 +122,8 @@ module.exports = function(crowi) {
       , Comment = crowi.model('Comment')
     ;
 
-    Comment.countCommentByPageId(savedComment.page)
-    .then(function(count) {
-      return Page.updateCommentCount(savedComment.page, count);
-    }).then(function(page) {
+    Page.updateCommentCount(savedComment.page)
+    .then(function(page) {
       debug('CommentCount Updated', page);
     }).catch(function() {
     });

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -16,7 +16,8 @@ module.exports = function(crowi) {
 
     , pageEvent = crowi.event('page')
 
-    , pageSchema;
+    , pageSchema
+    , Comment = crowi.model('Comment');
 
   function isPortalPath(path) {
     if (path.match(/.*\/$/)) {
@@ -305,18 +306,19 @@ module.exports = function(crowi) {
     });
   };
 
-  pageSchema.statics.updateCommentCount = function (page, num)
+  pageSchema.statics.updateCommentCount = function (pageId)
   {
     var self = this;
-
-    return new Promise(function(resolve, reject) {
-      self.update({_id: page}, {commentCount: num}, {}, function(err, data) {
+    var Comment = crowi.model("Comment");
+    return Comment.countCommentByPageId(pageId)
+    .then(function(count) {
+      self.update({_id: pageId}, {commentCount: count}, {}, function(err, data) {
         if (err) {
           debug('Update commentCount Error', err);
-          return reject(err);
+          throw err;
         }
 
-        return resolve(data);
+        return data;
       });
     });
   };

--- a/lib/routes/comment.js
+++ b/lib/routes/comment.js
@@ -82,15 +82,23 @@ module.exports = function(crowi, app) {
   api.remove = function(req, res){
     var commentId = req.body.comment_id;
     if (!commentId) {
-      return res.json(ApiResponse.error(`'comment_id' is undefined`));
+      return Promise.resolve(res.json(ApiResponse.error(`'comment_id' is undefined`)));
     }
 
-    return Comment.remove({_id: commentId})
-      .then(function() {
-        return res.json(ApiResponse.success({}));
-      }).catch(function(err) {
-        return res.json(ApiResponse.error(err));
+    return Comment.findById(commentId).exec()
+      .then(function(comment) {
+        return comment.remove()
+        .then(function() {
+           return Page.updateCommentCount(comment.page);
+        })
+        .then(function() {
+           return res.json(ApiResponse.success({})); 
+        });
+      })
+      .catch(function(err) {
+        return res.json(ApiResponse.error(err)); 
       });
+
   };
 
   return actions;


### PR DESCRIPTION
This PR fixes the bug of comment count not being updated when a comment of a page is deleted, **even when you reload the page**.

This means that there still remains a bug of comment count not being updated automatically after you click "Delete" button in the modal. Since comment counts are rendered using a template (pug?), it is a bit tricky to reflect the change without reloading the page. Hence, I will tackle this issue in another PR. 