### PR TITLE
Enable custom session name with SESSION_NAME env var

### DIFF
--- a/lib/crowi/index.js
+++ b/lib/crowi/index.js
@@ -172,6 +172,10 @@ Crowi.prototype.setupSessionConfig = function() {
       },
     };
 
+    if (self.env.SESSION_NAME) {
+        sessionConfig.name = self.env.SESSION_NAME;
+    }
+
     if (redisUrl) {
       var ru   = require('url').parse(redisUrl);
       var redis = require('redis');


### PR DESCRIPTION
# Overview
This PR enables custom session name when `SESSION_NAME` environment variable is passed.

# Motivation
I happened to run several web applications on the same domain but on different ports.
Since crowi-plus (and crowi) uses session library provided by expressjs, session name is by default `connect.sid`.
The problem is that when the other web apps use the same session name, the session is overwritten by each other. This is because sessions are namespaced only by domain (**NOT** including ports) Therefore, it causes an authentication problem.
Of course, we should use different domain names for different apps in production.
But it is still nice to have this feature, at least for me.

# Usage
## With CLI
### For development
`SESSION_NAME=connect.sid:8080 yarn server`
### For production
`SESSION_NAME=connect.sid:8080 yarn start`

### With env config file
You can add `SESSION_NAME` to `env.dev.js` and `env.prod.js`.