### PR TITLE
Fix: Insert title when a page is created

### DIFF
--- a/lib/views/not_found.html
+++ b/lib/views/not_found.html
@@ -69,6 +69,7 @@
     </div>
     {% endif %}
 
+    <script type="text/template" id="raw-text-original"># {{ path|path2name }}</script>
     {# list view #}
     <div class="active tab-pane page-list-container" id="revision-body">
       {% if pages.length == 0 %}


### PR DESCRIPTION
Before page editor started to use React (before January this year), a title was automatically inserted when creating a new page. 
But since then, it stopped working correctly. This PR fixes the bug.