### PR TITLE
changed bonsai version to latest 5.x (5.4.3)

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,7 +28,7 @@
     {
       "plan": "bonsai:sandbox-6",
       "options": {
-        "version": "5.1"
+        "version": "5.4.3"
       }
     }
   ]


### PR DESCRIPTION
bonsai:sandbox-6 5.1 is not available now on Heroku.

```
An error was encountered when contacting the add-on partner to create bonsai:sandbox-6: The requested version [5.1] is not available in this region on your plan. Available options are: 1.7.5, 2.4.0, 5.3.2, 5.4.3, 5.6.8, 6.0.1
```
